### PR TITLE
MacOSでpnpm api:build をした時のGemfile.lockの変更

### DIFF
--- a/apps/api/Gemfile.lock
+++ b/apps/api/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.0-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -216,6 +218,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -237,4 +240,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.1
+   2.4.4


### PR DESCRIPTION
おそらくPCの環境が別のために出た感じ？