### PR TITLE
カードコンポーネントにAccountPage用のサイズを追加

### DIFF
--- a/packages/ui/components/molecules/Card/index.tsx
+++ b/packages/ui/components/molecules/Card/index.tsx
@@ -1,8 +1,25 @@
 import Image from 'next/image'
 import ellipsis from '../../../libs/ellipsis'
 
-const Card = ({ bgColor, icon, username, img, description, caption }: Card) => {
+const Card = ({ size, bgColor, icon, username, img, description, caption }: Card) => {
   const CAPTION_MAX_LENGTH = 16
+
+  if (size === 'small') {
+    return (
+      <div className={`${bgColor} w-[422px] rounded-3xl`}>
+        <Image
+          src={img}
+          alt={description || 'image'}
+          width={422}
+          height={422}
+          style={{ objectFit: 'cover' }}
+        />
+        <div className='py-8 pl-8 font-sans text-2xl font-bold text-white'>
+          {ellipsis(caption, CAPTION_MAX_LENGTH)}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className={`${bgColor} w-[471px] rounded-3xl font-sans`}>

--- a/packages/ui/components/molecules/Card/index.tsx
+++ b/packages/ui/components/molecules/Card/index.tsx
@@ -13,6 +13,7 @@ const Card = ({ size, bgColor, icon, username, img, description, caption }: Card
           width={422}
           height={422}
           style={{ objectFit: 'cover' }}
+          className={`${size === 'small' ? 'rounded-t-3xl' : ''} `}
         />
         <div className='py-8 pl-8 font-sans text-2xl font-bold text-white'>
           {ellipsis(caption, CAPTION_MAX_LENGTH)}

--- a/packages/ui/components/molecules/Card/index.tsx
+++ b/packages/ui/components/molecules/Card/index.tsx
@@ -1,14 +1,8 @@
 import Image from 'next/image'
+import ellipsis from '../../../libs/ellipsis'
 
 const Card = ({ bgColor, icon, username, img, description, caption }: Card) => {
   const CAPTION_MAX_LENGTH = 16
-
-  const ellipsis = (str: string, length: number) => {
-    if (str.length < length) {
-      return str
-    }
-    return str.substring(0, length) + '...'
-  }
 
   return (
     <div className={`${bgColor} w-[471px] rounded-3xl font-sans`}>

--- a/packages/ui/components/molecules/Card/type.d.ts
+++ b/packages/ui/components/molecules/Card/type.d.ts
@@ -1,4 +1,5 @@
 declare type Card = {
+  size: 'small' | 'medium'
   bgColor: 'bg-orange' | 'bg-yellow' | 'bg-blue' | 'bg-navy'
   icon: string
   username: string

--- a/packages/ui/libs/ellipsis.spec.ts
+++ b/packages/ui/libs/ellipsis.spec.ts
@@ -1,0 +1,27 @@
+import ellipsis from './ellipsis'
+
+describe('文字列が指定の長さを超えた場合、...を付与する', () => {
+  it('文字列が指定した長さより短い場合', () => {
+    expect(ellipsis('hello', 2)).toEqual('he...')
+  })
+
+  it('文字列が指定した長さより長い場合', () => {
+    expect(ellipsis('hello', 10)).toEqual('hello')
+  })
+
+  it('長さが-であった場合', () => {
+    expect(ellipsis('hello', -1)).toEqual('hello')
+  })
+
+  it('文字列が空であった場合', () => {
+    expect(ellipsis('', 10)).toEqual('')
+  })
+
+  it('長さが0であった場合', () => {
+    expect(ellipsis('hello', 0)).toEqual('hello')
+  })
+
+  it('文字列が全角文字であった場合', () => {
+    expect(ellipsis('こんにちは', 2)).toEqual('こん...')
+  })
+})

--- a/packages/ui/libs/ellipsis.ts
+++ b/packages/ui/libs/ellipsis.ts
@@ -1,0 +1,12 @@
+const ellipsis = (str: string, length: number) => {
+  if (length <= 0) {
+    return str
+  }
+
+  if (str.length < length) {
+    return str
+  }
+  return str.substring(0, length) + '...'
+}
+
+export default ellipsis


### PR DESCRIPTION
AccountPage作成に必要なカードコンポーネントの修正となります。

TopPageに比べ、サイズが多少 小さい。